### PR TITLE
Remove entryPoint from IContainerRuntime

### DIFF
--- a/api-report/container-runtime-definitions.api.md
+++ b/api-report/container-runtime-definitions.api.md
@@ -16,7 +16,6 @@ import { IDocumentMessage } from '@fluidframework/protocol-definitions';
 import { IDocumentStorageService } from '@fluidframework/driver-definitions';
 import { IEventProvider } from '@fluidframework/common-definitions';
 import { IFluidDataStoreContextDetached } from '@fluidframework/runtime-definitions';
-import { IFluidHandle } from '@fluidframework/core-interfaces';
 import { IFluidRouter } from '@fluidframework/core-interfaces';
 import { IHelpMessage } from '@fluidframework/protocol-definitions';
 import { ILoaderOptions } from '@fluidframework/container-definitions';
@@ -40,7 +39,6 @@ export interface IContainerRuntime extends IProvideContainerRuntime, IProvideFlu
     createDetachedRootDataStore(pkg: Readonly<string[]>, rootDataStoreId: string): IFluidDataStoreContextDetached;
     // (undocumented)
     readonly deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;
-    readonly entryPoint?: IFluidHandle<FluidObject>;
     // (undocumented)
     readonly flushMode: FlushMode;
     getAbsoluteUrl(relativeUrl: string): Promise<string | undefined>;

--- a/examples/data-objects/codemirror/src/index.ts
+++ b/examples/data-objects/codemirror/src/index.ts
@@ -15,7 +15,6 @@ import {
     RuntimeFactoryHelper,
 } from "@fluidframework/runtime-utils";
 import { MountableView } from "@fluidframework/view-adapters";
-import { FluidObject, IProvideFluidRouter } from "@fluidframework/core-interfaces";
 import {
     CodeMirrorComponent,
     SmdeFactory,
@@ -37,25 +36,13 @@ const defaultComponentId = "default";
 const smde = new SmdeFactory();
 
 const viewRequestHandler = async (request: RequestParser, runtime: IContainerRuntime) => {
-    const entryPoint: FluidObject<IProvideFluidRouter> | undefined = await runtime.entryPoint?.get();
-
-    // We know that the ProseMirrorRuntimeFactory below sets the entryPoint of the ContainerRuntime,
-    // and furthermore that it sets it to an object that implements IFluidRouter, but best practice is
-    // to check explicitly anyway.
-    if (entryPoint === undefined) {
-        throw new Error("entryPoint for the Container Runtime was not set");
-    }
-    if (entryPoint.IFluidRouter === undefined) {
-        throw new Error("entryPoint for the Container Runtime does not implement IFluidRouter");
-    }
-
     if (request.pathParts.length === 0) {
         const objectRequest = RequestParser.create({
             url: ``,
             headers: request.headers,
         });
         const codeMirror = await requestFluidObject<CodeMirrorComponent>(
-            entryPoint.IFluidRouter,
+            await runtime.getRootDataStore(defaultComponentId),
             objectRequest);
         return {
             status: 200,
@@ -88,8 +75,6 @@ class CodeMirrorFactory extends RuntimeFactoryHelper {
             undefined, // runtimeOptions
             undefined, // containerScope
             existing,
-            undefined, // containerRuntimeCtor
-            async (containerRuntime: IContainerRuntime) => containerRuntime.getRootDataStore(defaultComponentId),
         );
 
         return runtime;

--- a/examples/data-objects/prosemirror/src/index.ts
+++ b/examples/data-objects/prosemirror/src/index.ts
@@ -7,7 +7,6 @@ import { mountableViewRequestHandler } from "@fluidframework/aqueduct";
 import { IContainerContext } from "@fluidframework/container-definitions";
 import { ContainerRuntime } from "@fluidframework/container-runtime";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
-import { FluidObject, IProvideFluidRouter } from "@fluidframework/core-interfaces";
 import { buildRuntimeRequestHandler } from "@fluidframework/request-handler";
 import { IFluidDataStoreFactory } from "@fluidframework/runtime-definitions";
 import { requestFluidObject, RequestParser, RuntimeFactoryHelper } from "@fluidframework/runtime-utils";
@@ -21,25 +20,13 @@ const defaultComponentId = "default";
 const smde = new ProseMirrorFactory();
 
 const viewRequestHandler = async (request: RequestParser, runtime: IContainerRuntime) => {
-    const entryPoint: FluidObject<IProvideFluidRouter> | undefined = await runtime.entryPoint?.get();
-
-    // We know that the ProseMirrorRuntimeFactory below sets the entryPoint of the ContainerRuntime,
-    // and furthermore that it sets it to an object that implements IFluidRouter, but best practice is
-    // to check explicitly anyway.
-    if (entryPoint === undefined) {
-        throw new Error("entryPoint for the Container Runtime was not set");
-    }
-    if (entryPoint.IFluidRouter === undefined) {
-        throw new Error("entryPoint for the Container Runtime does not implement IFluidRouter");
-    }
-
     if (request.pathParts.length === 0) {
         const objectRequest = RequestParser.create({
             url: ``,
             headers: request.headers,
         });
         const proseMirror = await requestFluidObject<ProseMirror>(
-            entryPoint.IFluidRouter,
+            await runtime.getRootDataStore(defaultComponentId),
             objectRequest);
         return { status: 200, mimeType: "fluid/view", value: new ProseMirrorView(proseMirror.collabManager) };
     }
@@ -68,8 +55,6 @@ class ProseMirrorRuntimeFactory extends RuntimeFactoryHelper {
             undefined, // runtimeOptions
             undefined, // containerScope
             existing,
-            undefined, // containerRuntimeCtor
-            async (containerRuntime: IContainerRuntime) => containerRuntime.getRootDataStore(defaultComponentId),
         );
 
         return runtime;

--- a/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
@@ -14,7 +14,6 @@ import {
     IResponse,
     IFluidRouter,
     FluidObject,
-    IFluidHandle,
 } from "@fluidframework/core-interfaces";
 import { IDocumentStorageService } from "@fluidframework/driver-definitions";
 import {
@@ -85,21 +84,6 @@ export interface IContainerRuntime extends
      * Indicates the attachment state of the container to a host service.
      */
     readonly attachState: AttachState;
-
-    /**
-     * Exposes a handle to the root object / entryPoint of the container.
-     * Use this as the primary way of getting access to the user-defined logic within the container.
-     * If this property is undefined (meaning that exposing the entryPoint hasn't been implemented in a particular
-     * scenario) fall back to the current approach of requesting the root object of the container through the request
-     * pattern.
-     *
-     * See {@link @fluidframework/common-definitions#IContainer.entryPoint}
-     *
-     * @remarks The plan is that eventually IContainerRuntime will no longer have a resolveHandle() method, this property
-     * will become non-optional and return an IFluidHandle (no undefined), and it will become the only way to access
-     * the handle to the entryPoint for the container.
-     */
-    readonly entryPoint?: IFluidHandle<FluidObject>;
 
     /**
      * Returns the runtime of the data store.


### PR DESCRIPTION
## Description

Experiment on top of https://github.com/microsoft/FluidFramework/pull/12487 . Removes `entryPoint` from `IContainerRuntime`. Existing code only needs it in `IRuntime` for the container context to be able to use it (and expose it to the `Container`).