### PR TITLE
chore: Stop including unnecessary files in published packages (packages/{common,tools,utils})

### DIFF
--- a/packages/common/container-definitions/.npmignore
+++ b/packages/common/container-definitions/.npmignore
@@ -1,6 +1,0 @@
-nyc
-*.log
-**/*.tsbuildinfo
-src/test
-dist/test
-**/_api-extractor-temp/**

--- a/packages/common/container-definitions/package.json
+++ b/packages/common/container-definitions/package.json
@@ -14,6 +14,13 @@
 	"main": "dist/index.js",
 	"module": "lib/index.js",
 	"types": "dist/index.d.ts",
+	"files": [
+		"dist/**",
+		"!dist/test/**",
+		"lib/**",
+		"src/**",
+		"!src/test/**"
+	],
 	"scripts": {
 		"build": "concurrently npm:build:compile npm:lint && npm run build:docs",
 		"build:commonjs": "npm run tsc && npm run typetests:gen && npm run build:test",

--- a/packages/common/core-interfaces/.npmignore
+++ b/packages/common/core-interfaces/.npmignore
@@ -1,6 +1,0 @@
-nyc
-*.log
-**/*.tsbuildinfo
-src/test
-dist/test
-**/_api-extractor-temp/**

--- a/packages/common/core-interfaces/package.json
+++ b/packages/common/core-interfaces/package.json
@@ -14,6 +14,13 @@
 	"main": "dist/index.js",
 	"module": "lib/index.js",
 	"types": "dist/index.d.ts",
+	"files": [
+		"dist/**",
+		"!dist/test/**",
+		"lib/**",
+		"src/**",
+		"!src/test/**"
+	],
 	"scripts": {
 		"build": "concurrently npm:build:compile npm:lint && npm run build:docs",
 		"build:commonjs": "npm run tsc && npm run typetests:gen && npm run build:test",

--- a/packages/common/core-utils/.npmignore
+++ b/packages/common/core-utils/.npmignore
@@ -1,6 +1,0 @@
-nyc
-*.log
-**/*.tsbuildinfo
-src/test
-dist/test
-**/_api-extractor-temp/**

--- a/packages/common/core-utils/package.json
+++ b/packages/common/core-utils/package.json
@@ -14,6 +14,13 @@
 	"main": "dist/index.js",
 	"module": "lib/index.js",
 	"types": "dist/index.d.ts",
+	"files": [
+		"dist/**",
+		"!dist/test/**",
+		"lib/**",
+		"src/**",
+		"!src/test/**"
+	],
 	"scripts": {
 		"bench": "mocha --timeout 999999 --perfMode --parentProcess --fgrep @Benchmark --reporter \"../../../node_modules/@fluid-tools/benchmark/dist/MochaReporter.js\"",
 		"bench:profile": "mocha --v8-prof --timeout 999999 --perfMode --fgrep @Benchmark --reporter \"../../../node_modules/@fluid-tools/benchmark/dist/MochaReporter.js\" && node --prof-process isolate-0x*-v8.log > profile.txt && rm isolate-0x*-v8.log && cat profile.txt",

--- a/packages/common/driver-definitions/.npmignore
+++ b/packages/common/driver-definitions/.npmignore
@@ -1,6 +1,0 @@
-nyc
-*.log
-**/*.tsbuildinfo
-src/test
-dist/test
-**/_api-extractor-temp/**

--- a/packages/common/driver-definitions/package.json
+++ b/packages/common/driver-definitions/package.json
@@ -14,6 +14,13 @@
 	"main": "dist/index.js",
 	"module": "lib/index.js",
 	"types": "dist/index.d.ts",
+	"files": [
+		"dist/**",
+		"!dist/test/**",
+		"lib/**",
+		"src/**",
+		"!src/test/**"
+	],
 	"scripts": {
 		"build": "concurrently npm:build:compile npm:lint && npm run build:docs",
 		"build:compile": "concurrently npm:typetests:gen npm:tsc npm:build:esnext",

--- a/packages/tools/fetch-tool/.npmignore
+++ b/packages/tools/fetch-tool/.npmignore
@@ -1,5 +1,0 @@
-nyc
-*.log
-**/*.tsbuildinfo
-src/test
-dist/test

--- a/packages/tools/fetch-tool/package.json
+++ b/packages/tools/fetch-tool/package.json
@@ -14,6 +14,13 @@
 	"bin": {
 		"fluid-fetch": "bin/fluid-fetch"
 	},
+	"files": [
+		"dist/**",
+		"!dist/test/**",
+		"lib/**",
+		"src/**",
+		"!src/test/**"
+	],
 	"scripts": {
 		"build": "concurrently npm:build:compile npm:lint",
 		"build:compile": "npm run tsc",

--- a/packages/tools/fluid-runner/.npmignore
+++ b/packages/tools/fluid-runner/.npmignore
@@ -1,6 +1,0 @@
-nyc
-*.log
-**/*.tsbuildinfo
-src/test
-dist/test
-**/_api-extractor-temp/**

--- a/packages/tools/fluid-runner/package.json
+++ b/packages/tools/fluid-runner/package.json
@@ -15,6 +15,13 @@
 	"bin": {
 		"fluid-runner": "bin/fluid-runner"
 	},
+	"files": [
+		"dist/**",
+		"!dist/test/**",
+		"lib/**",
+		"src/**",
+		"!src/test/**"
+	],
 	"scripts": {
 		"build": "concurrently npm:build:compile npm:lint",
 		"build:commonjs": "npm run tsc && npm run typetests:gen && npm run build:test",

--- a/packages/tools/replay-tool/.npmignore
+++ b/packages/tools/replay-tool/.npmignore
@@ -1,3 +1,0 @@
-nyc
-*.log
-**/*.tsbuildinfo

--- a/packages/tools/replay-tool/package.json
+++ b/packages/tools/replay-tool/package.json
@@ -17,6 +17,13 @@
 	"bin": {
 		"replayTool": "bin/replayTool"
 	},
+	"files": [
+		"dist/**",
+		"!dist/test/**",
+		"lib/**",
+		"src/**",
+		"!src/test/**"
+	],
 	"scripts": {
 		"build": "concurrently npm:build:compile npm:lint",
 		"build:compile": "npm run tsc",

--- a/packages/tools/webpack-fluid-loader/.npmignore
+++ b/packages/tools/webpack-fluid-loader/.npmignore
@@ -1,6 +1,0 @@
-nyc
-*.log
-**/*.tsbuildinfo
-src/test
-dist/test
-**/_api-extractor-temp/**

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -16,6 +16,13 @@
 		"moniker": "@fluidframework/server-services-client/dist/generateNames.js"
 	},
 	"types": "dist/index.d.ts",
+	"files": [
+		"dist/**",
+		"!dist/test/**",
+		"lib/**",
+		"src/**",
+		"!src/test/**"
+	],
 	"scripts": {
 		"build": "concurrently npm:build:compile npm:lint",
 		"build:commonjs": "npm run tsc && npm run typetests:gen && npm run build:test",

--- a/packages/utils/odsp-doclib-utils/.npmignore
+++ b/packages/utils/odsp-doclib-utils/.npmignore
@@ -1,6 +1,0 @@
-nyc
-*.log
-**/*.tsbuildinfo
-src/test
-dist/test
-**/_api-extractor-temp/**

--- a/packages/utils/odsp-doclib-utils/package.json
+++ b/packages/utils/odsp-doclib-utils/package.json
@@ -14,6 +14,13 @@
 	"main": "dist/index.js",
 	"module": "lib/index.js",
 	"types": "dist/index.d.ts",
+	"files": [
+		"dist/**",
+		"!dist/test/**",
+		"lib/**",
+		"src/**",
+		"!src/test/**"
+	],
 	"scripts": {
 		"build": "npm run build:genver && concurrently npm:build:compile npm:lint",
 		"build:commonjs": "npm run tsc && npm run typetests:gen && npm run build:test",

--- a/packages/utils/telemetry-utils/.npmignore
+++ b/packages/utils/telemetry-utils/.npmignore
@@ -1,6 +1,0 @@
-nyc
-*.log
-**/*.tsbuildinfo
-src/test
-dist/test
-**/_api-extractor-temp/**

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -18,6 +18,13 @@
 		"./lib/indexNode.js": "./lib/indexBrowser.js"
 	},
 	"types": "dist/index.d.ts",
+	"files": [
+		"dist/**",
+		"!dist/test/**",
+		"lib/**",
+		"src/**",
+		"!src/test/**"
+	],
 	"scripts": {
 		"build": "npm run build:genver && concurrently npm:build:compile npm:lint && npm run build:docs",
 		"build:commonjs": "npm run tsc && npm run typetests:gen && npm run build:test",

--- a/packages/utils/tool-utils/.npmignore
+++ b/packages/utils/tool-utils/.npmignore
@@ -1,6 +1,0 @@
-nyc
-*.log
-**/*.tsbuildinfo
-src/test
-dist/test
-**/_api-extractor-temp/**

--- a/packages/utils/tool-utils/package.json
+++ b/packages/utils/tool-utils/package.json
@@ -14,6 +14,13 @@
 	"main": "dist/index.js",
 	"module": "lib/index.js",
 	"types": "dist/index.d.ts",
+	"files": [
+		"dist/**",
+		"!dist/test/**",
+		"lib/**",
+		"src/**",
+		"!src/test/**"
+	],
 	"scripts": {
 		"build": "npm run build:genver && concurrently npm:build:compile npm:lint && npm run build:docs",
 		"build:commonjs": "npm run tsc && npm run typetests:gen && npm run build:test",


### PR DESCRIPTION
## Description

Follow up to https://github.com/microsoft/FluidFramework/pull/15532. Same change, more packages.

PR within my fork for now to hide the changes from 15532.

## Reviewer Guidance

Diffs all look reasonable:

![fluidframework-container-definitions](https://github.com/alexvy86/FluidFramework/assets/716334/689fe7aa-da55-4585-a484-110568ee9ee1)
![fluidframework-core-interfaces](https://github.com/alexvy86/FluidFramework/assets/716334/1097db64-39e5-4176-b36e-0e0feacb0d40)
![fluidframework-core-utils](https://github.com/alexvy86/FluidFramework/assets/716334/7758a692-0d12-4b8d-86a4-979b91821995)
![fluidframework-driver-definitions](https://github.com/alexvy86/FluidFramework/assets/716334/0b730449-1bb1-4c22-bf0f-a1ee2724962b)
![fluidframework-fluid-runner](https://github.com/alexvy86/FluidFramework/assets/716334/ea297c46-64da-4d4b-a78e-e1473d40c596)
![fluidframework-odsp-doclib-utils](https://github.com/alexvy86/FluidFramework/assets/716334/09eb1680-030d-4aa7-b662-79bd72040470)
![fluidframework-telemetry-utils](https://github.com/alexvy86/FluidFramework/assets/716334/e8e2e373-678d-4978-aab0-44f3b4bd4ae0)
![fluidframework-tool-utils](https://github.com/alexvy86/FluidFramework/assets/716334/b5613ffb-aaa9-4a10-9095-86828cd995c4)
![fluid-internal-replay-tool](https://github.com/alexvy86/FluidFramework/assets/716334/9cd82032-be50-4879-815a-72af1943ed22)
![fluid-tools-fetch-tool](https://github.com/alexvy86/FluidFramework/assets/716334/b74f7e7c-a15b-4165-aef1-c57bec64a1c3)
![fluid-tools-webpack-fluid-loader](https://github.com/alexvy86/FluidFramework/assets/716334/5613d8a9-b572-47d3-8a23-39fc54ddb5c5)
